### PR TITLE
Ensure that 'runlist' is always iterable

### DIFF
--- a/recuperabit/fs/ntfs.py
+++ b/recuperabit/fs/ntfs.py
@@ -77,6 +77,8 @@ def parse_mft_attr(attr):
 
     if header['non_resident']:
         nonresident = unpack(attr, attr_nonresident_fmt)
+        if nonresident['runlist'] is None:
+            nonresident['runlist'] = list()
         header.update(nonresident)
     else:
         resident = unpack(attr, attr_resident_fmt)


### PR DESCRIPTION
'runlist' may be unpacked to `None` in some cases, but the remainder of the
code expects the runlist to be iterable.  Set 'runlist' to an empty list in
this case to fix this.