### PR TITLE
Fix type error when adding padded bytes.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,9 +4,6 @@
 !.vscode/launch.json
 *.code-workspace
 
-# PyCharm
-.idea/
-
 ### Python ###
 # Byte-compiled / optimized / DLL files
 __pycache__/

--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,9 @@
 !.vscode/launch.json
 *.code-workspace
 
+# PyCharm
+.idea/
+
 ### Python ###
 # Byte-compiled / optimized / DLL files
 __pycache__/

--- a/recuperabit/fs/ntfs.py
+++ b/recuperabit/fs/ntfs.py
@@ -319,7 +319,7 @@ class NTFSFile(File):
             logging.warning(
                 'Failed to read byte(s). Padding with 0x00. Offset: {} Size: '
                 '{}'.format(offset, size))
-            dump += bytearray('\x00' * (size - len(dump)))
+            dump += bytearray(b'\x00' * (size - len(dump)))
         return dump
 
     def content_iterator(self, partition, image, datas):


### PR DESCRIPTION
During recovery of one of the partitions, I got the following error:
```
WARNING:root:Failed to read byte(s). Padding with 0x00. Offset: 113928912896 Size: 131072
Traceback (most recent call last):
  File "main.py", line 401, in <module>
    main()
  File "main.py", line 398, in main
    interpret(cmd, arguments, parts, shorthands, args.outputdir)
  File "main.py", line 257, in interpret
    restore_part(i, parts, shorthands, -1, outdir)
  File "main.py", line 278, in restore_part
    logic.recursive_restore(myfile, part, partition_dir)
  File "/home/Rober/Programas/RecuperaBit/recuperabit/logic.py", line 259, in recursive_restore
    recursive_restore(child, part, outputdir, make_dirs=False)
  File "/home/Rober/Programas/RecuperaBit/recuperabit/logic.py", line 259, in recursive_restore
    recursive_restore(child, part, outputdir, make_dirs=False)
  File "/home/Rober/Programas/RecuperaBit/recuperabit/logic.py", line 259, in recursive_restore
    recursive_restore(child, part, outputdir, make_dirs=False)
  [Previous line repeated 1 more time]
  File "/home/Rober/Programas/RecuperaBit/recuperabit/logic.py", line 245, in recursive_restore
    for piece in content:
  File "/home/Rober/Programas/RecuperaBit/recuperabit/fs/ntfs.py", line 366, in content_iterator
    partial = self._padded_bytes(image, position, amount)
  File "/home/Rober/Programas/RecuperaBit/recuperabit/fs/ntfs.py", line 322, in _padded_bytes
    dump += bytearray('\x00' * (size - len(dump)))
TypeError: string argument without an encoding
```
This PR just prefixes the string with `b` to convert it to a bytes instance instead of str, so that the function doesn't require an encoding.
