### PR TITLE
Restore modification time if possible

### DIFF
--- a/recuperabit/fs/ntfs.py
+++ b/recuperabit/fs/ntfs.py
@@ -306,6 +306,7 @@ class NTFSFile(File):
             parent_id = first['parent_entry']
             File.set_parent(self, parent_id)
             File.set_offset(self, offset)
+            first = attrs.get('$STANDARD_INFORMATION', filtered[0])['content']
             File.set_mac(
                 self, first['modification_time'],
                 first['access_time'], first['creation_time']

--- a/recuperabit/fs/ntfs.py
+++ b/recuperabit/fs/ntfs.py
@@ -297,6 +297,8 @@ class NTFSFile(File):
         if not hasname:
             name = 'File_%s' % index
 
+        std_info = attrs.get('$STANDARD_INFORMATION')
+
         is_dir = (parsed['flags'] & 0x02) > 0 and not len(ads)
         is_del = (parsed['flags'] & 0x01) == 0
         File.__init__(self, index, name, size, is_dir, is_del, is_ghost)
@@ -306,10 +308,12 @@ class NTFSFile(File):
             parent_id = first['parent_entry']
             File.set_parent(self, parent_id)
             File.set_offset(self, offset)
-            first = attrs.get('$STANDARD_INFORMATION', filtered[0])['content']
+            time_attribute = std_info or filtered[0]
+        if time_attribute and 'content' in time_attribute:
             File.set_mac(
-                self, first['modification_time'],
-                first['access_time'], first['creation_time']
+                self, time_attribute['content']['modification_time'],
+                time_attribute['content']['access_time'],
+                time_attribute['content']['creation_time'],
             )
         self.ads = ads
 

--- a/recuperabit/fs/ntfs_fmt.py
+++ b/recuperabit/fs/ntfs_fmt.py
@@ -19,10 +19,12 @@
 # along with RecuperaBit. If not, see <http://www.gnu.org/licenses/>.
 
 
-from datetime import datetime
+from datetime import datetime, timezone, timedelta
 
 from ..utils import printable, unpack
 
+
+time_start = datetime(1601, 1, 1, tzinfo=timezone.utc)
 
 def printable_name(name):
     """Return a printable name decoded in UTF-16."""
@@ -44,7 +46,7 @@ def windows_time(timestamp):
     """Convert a date-time value from Microsoft filetime to UTC."""
     try:
         value = int.from_bytes(timestamp, byteorder='little', signed=False)
-        converted = datetime.utcfromtimestamp(value/10.**7 - 11644473600)
+        converted = time_start + timedelta(milliseconds = value//10000)
         return converted
     except (ValueError, OverflowError, OSError):
         return None

--- a/recuperabit/logic.py
+++ b/recuperabit/logic.py
@@ -25,6 +25,7 @@ import logging
 import os
 import os.path
 import sys
+import time
 import types
 
 from .utils import tiny_repr
@@ -252,6 +253,12 @@ def recursive_restore(node, part, outputdir, make_dirs=True):
                 open(restore_path, 'wb').close()
     except IOError:
         logging.error(u'IOError when trying to create %s', restore_path)
+
+    mtime, atime, ctime = node.get_mac()
+    if mtime is not None:
+        mtime = min(mtime, atime or mtime, ctime or mtime)
+        mtime = time.mktime(mtime.astimezone().timetuple())
+        os.utime(restore_path, (mtime, mtime))
 
     if is_directory:
         for child in node.children:

--- a/recuperabit/logic.py
+++ b/recuperabit/logic.py
@@ -254,11 +254,12 @@ def recursive_restore(node, part, outputdir, make_dirs=True):
     except IOError:
         logging.error(u'IOError when trying to create %s', restore_path)
 
-    mtime, atime, ctime = node.get_mac()
+    # Restore Modification + Access time
+    mtime, atime, _ = node.get_mac()
     if mtime is not None:
-        mtime = min(mtime, atime or mtime, ctime or mtime)
+        atime = time.mktime(atime.astimezone().timetuple())
         mtime = time.mktime(mtime.astimezone().timetuple())
-        os.utime(restore_path, (mtime, mtime))
+        os.utime(restore_path, (atime, mtime))
 
     if is_directory:
         for child in node.children:


### PR DESCRIPTION
Use $STANDARD_INFORMATION for modification time because only it is preserved on file copy. Reference:
https://www.forensixchange.com/posts/19_04_22_win10_ntfs_time_rules/

My fix may not be the best, because I haven't read full code base, but it allowed me to restore photos with correct modification time on them (file capture time) which have been copied onto the damaged drive. So, let's discuss if I didn't catch something.