### PR TITLE
Issue #119 Fix - UnboundLocalError (time_attribute) - recuperabit/fs/ntfs.py

### DIFF
--- a/recuperabit/fs/ntfs.py
+++ b/recuperabit/fs/ntfs.py
@@ -303,6 +303,9 @@ class NTFSFile(File):
         is_dir = (parsed['flags'] & 0x02) > 0 and not len(ads)
         is_del = (parsed['flags'] & 0x01) == 0
         File.__init__(self, index, name, size, is_dir, is_del, is_ghost)
+
+        time_attribute = None
+
         # Additional attributes
         if hasname:
             first = filtered[0]['content']


### PR DESCRIPTION
Solved a [minor bug](https://github.com/Lazza/RecuperaBit/issues/119) in ["recuperabit/fs/ntfs.py"](https://github.com/Lazza/RecuperaBit/blob/master/recuperabit/fs/ntfs.py) to avoid the following runtime error:

> "UnboundLocalError: local variable 'time_attribute' referenced before assignment"

 by initially setting variable `time_attribute = None`. 