### PR TITLE
Add readline support

### DIFF
--- a/main.py
+++ b/main.py
@@ -28,6 +28,7 @@ import logging
 import os.path
 import pickle
 import sys
+import readline
 
 from recuperabit import logic, utils
 # scanners

--- a/main.py
+++ b/main.py
@@ -28,7 +28,10 @@ import logging
 import os.path
 import pickle
 import sys
-import readline
+try:
+    import readline
+except ImportError:
+    pass
 
 from recuperabit import logic, utils
 # scanners


### PR DESCRIPTION
This should add command history and some basic readline commands to the main command line prompt.  I have tested this on my Linux system with CPython and Pypy (NixOS, specifically).