### PR TITLE
support redirection and pipe in the commands

### DIFF
--- a/main.py
+++ b/main.py
@@ -27,6 +27,7 @@ import locale
 import logging
 import os.path
 import pickle
+import shlex
 import sys
 
 from recuperabit import logic, utils
@@ -368,10 +369,12 @@ def main():
     while True:
         print('\nWrite command ("help" for details):')
         try:
-            command = input('> ').split(' ')
+            command = shlex.split(input('> ').strip())
         except (EOFError, KeyboardInterrupt):
             print('')
             exit(0)
+        if len(command) == 0:
+            continue
         cmd = command[0]
         arguments = command[1:]
         interpret(cmd, arguments, parts, shorthands, args.outputdir)


### PR DESCRIPTION
fix #9 
based on (and replace) #129

Things like:
- **output redirection**, eg: `recoverable > /tmp/a.txt` become possible (for any other command)
- **piping**, eg: `locate ... | grep foobar` too
- and combining of **piping** + **redirection** too, eg: `help | grep z > /tmp/test.txt`
