### PR TITLE
Confine restore output to the output directory

### DIFF
--- a/src/recuperabit/logic.py
+++ b/src/recuperabit/logic.py
@@ -222,6 +222,13 @@ def makedirs(path: str) -> bool:
     return True
 
 
+def _is_within_directory(directory: str, target: str) -> bool:
+    """Return True if the real path of target is confined within directory."""
+    real_directory = os.path.realpath(directory)
+    real_target = os.path.realpath(target)
+    return os.path.commonpath([real_directory, real_target]) == real_directory
+
+
 def recursive_restore(
     node: "File", part: "Partition", outputdir: str, make_dirs: bool = True
 ) -> None:
@@ -233,6 +240,16 @@ def recursive_restore(
     file_path = os.path.join(parent_path, node.name)
     restore_parent_path = os.path.join(outputdir, parent_path)
     restore_path = os.path.join(outputdir, file_path)
+
+    if not _is_within_directory(outputdir, restore_path) or not _is_within_directory(
+        outputdir, restore_parent_path
+    ):
+        logging.error(
+            "Refusing to restore #%s %s outside of the output directory",
+            node.index,
+            file_path,
+        )
+        return
 
     try:
         content = node.get_content(part)


### PR DESCRIPTION
Follow-up to the report I sent by email (RCB-2026-0001 / RESTORE-001), the one confirmed with a
runtime PoC.

## The issue

`recursive_restore()` writes recovered files using names reconstructed from the image's
`$FILE_NAME` attributes (`logic.py:233-235`), with no check that the resulting path stays inside
`outputdir`:

```python
file_path = os.path.join(parent_path, node.name)
restore_parent_path = os.path.join(outputdir, parent_path)
restore_path = os.path.join(outputdir, file_path)
```

`printable()` (`utils.py`) only strips Unicode control characters, so path separators, drive
letters, and `..` sequences coming from the image survive untouched. Since the image being
analyzed is inherently untrusted evidence, a crafted `$FILE_NAME` (an absolute path, a UNC path,
or `../../..`) makes `os.path.join()` discard or escape the output directory, and `restore` writes
recovered content anywhere on the analyst's workstation instead of confined to `-o`.

## The fix

Add a confinement check (`realpath` + `commonpath`) before any `mkdir`/write in
`recursive_restore`, and skip + log the entry instead of writing outside `outputdir`.

## Verification

I have a small script that drives `recursive_restore()` directly with a crafted node name
(absolute path and `../..`) and checks whether the write lands outside the output directory. It
confirms the write escapes on `master`, and is refused (logged, not written) with this patch
applied. Happy to attach it here if useful, or you're welcome to write your own — didn't want to
assume you'd want a PoC script sitting in the repo/PR itself.