### PR TITLE
Replace pickle with json for the scan save file

### DIFF
--- a/src/recuperabit/cli.py
+++ b/src/recuperabit/cli.py
@@ -22,9 +22,9 @@
 import argparse
 import codecs
 import itertools
+import json
 import logging
 import os.path
-import pickle
 import sys
 from typing import TYPE_CHECKING
 
@@ -326,7 +326,7 @@ def main():
         else:
             logging.info("Checking if results already exist.")
             try:
-                savefile = open(args.savefile, "rb")
+                savefile = open(args.savefile, "r")
                 logging.info("Results will be read from %s", args.savefile)
                 read_results = True
             except IOError:
@@ -337,9 +337,13 @@ def main():
     if read_results:
         logging.info("The save file exists. Trying to read it...")
         try:
-            indexes = pickle.load(savefile)
+            indexes = json.load(savefile)
             savefile.close()
-        except IndexError:
+            if not isinstance(indexes, list) or not all(
+                isinstance(i, int) for i in indexes
+            ):
+                raise ValueError("save file must contain a list of integers")
+        except (ValueError, json.JSONDecodeError):
             logging.error("Malformed save file!")
             exit(1)
     else:
@@ -370,8 +374,8 @@ def main():
 
     if write_results:
         logging.info("Saving results to %s", args.savefile)
-        with open(args.savefile, "wb") as savefile:
-            pickle.dump(interesting, savefile)
+        with open(args.savefile, "w") as savefile:
+            json.dump(interesting, savefile)
 
     # Ask for partitions
     parts: dict[int, "Partition"] = {}


### PR DESCRIPTION
Follow-up to the report I sent by email (RCB-2026-0002 / SAVE-001), the one confirmed with a
runtime PoC.

## The issue

The `-s/--savefile` is reloaded with `pickle.load` (`cli.py:340`), guarded only by
`except IndexError`. `pickle.load` runs arbitrary code at deserialization time (a crafted
`__reduce__`), before the confirmation prompt and before any disk image is even parsed.

I framed this in the original report as "save files get shared/archived/downloaded between
analysts", which you pushed back on and fairly so: if the only realistic way to hit this is
loading your own tampered file, it's not really an attacker-facing bug. I'm not asking you to
treat this as urgent. I'm opening it anyway because the fix is basically free: the persisted value
is only a `List[int]` of sector indexes (`utils.feed_all`), so there's no reason to use a format
that can execute code for it.

## The fix

Swap `pickle.dump`/`pickle.load` for `json.dump`/`json.load`, and validate the loaded value is
actually a list of ints (anything else is treated as a malformed save file, same as before).

## Trade-off

This changes the save-file format, so old `.pkl` files won't load anymore (they'll just be
reported as malformed, same as any other corrupt file) — old scans would need to be redone.
Wanted to flag that explicitly rather than have it be a surprise.

## Verification

Ran the same "malicious `__reduce__` gadget" against the patched CLI: previously it wrote a marker
file (code executed), now the CLI logs "Malformed save file!" and exits without running anything.