### PR TITLE
Isolate command dispatch and the deep-parse phase from crashing the whole session

### DIFF
--- a/src/recuperabit/cli.py
+++ b/src/recuperabit/cli.py
@@ -376,7 +376,10 @@ def main():
     # Ask for partitions
     parts: dict[int, "Partition"] = {}
     for scanner in scanners:
-        parts.update(scanner.get_partitions())
+        try:
+            parts.update(scanner.get_partitions())
+        except Exception as exc:  # pylint: disable=W0703
+            logging.error("Partition scan failed for %s: %s", scanner, exc)
 
     shorthands = list(enumerate(parts))
 
@@ -390,7 +393,10 @@ def main():
             exit(0)
         cmd = command[0]
         arguments = command[1:]
-        interpret(cmd, arguments, parts, shorthands, args.outputdir)
+        try:
+            interpret(cmd, arguments, parts, shorthands, args.outputdir)
+        except Exception as exc:  # pylint: disable=W0703
+            logging.error("Command '%s' failed: %s", cmd, exc)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
This is a follow-up after your reply about the original report -- I went back and hand-verified
the rest of it rather than sending another big list. Most of what I found individually is a crafted
NTFS structure that raises an uncaught exception somewhere in the parser (a non-directory root
record, a cyclic file graph, a None-valued timestamp field, a truncated attribute/INDX record,
a pre-1970 timestamp). Rather than reporting each one separately, they all share the same
amplifier: there is no exception isolation around the two places that actually run on
attacker-controlled data, so any single one of them kills the entire session instead of just that
one record or command.

## The two gaps

1. The initial deep-parse phase (`parts.update(scanner.get_partitions())` in `main()`) has no
   exception handling at all.
2. The REPL's command dispatch (`interpret(...)` inside the `while True` loop) likewise has none --
   only `input()` itself is guarded (`EOFError`/`KeyboardInterrupt`).

## The fix

Wrap both call sites in `except Exception: log and continue`, so a single bad record or command
degrades gracefully instead of aborting the whole analysis.

## What this does and doesn't fix

This doesn't fix the individual root causes -- each parser defect is still there. What it does is
stop any one of them from taking down the whole tool. I concretely verified this converts a hard,
unhandled crash into a logged, recoverable error for each of these (all independently reproduced
against a minimal in-memory `Partition`/`File`, no crafted disk image needed to demonstrate):

- a crafted MFT root record (#5) that isn't flagged as a directory (`Partition.rebuild` ->
  `set_root` raises a bare `TypeError`)
- a cyclic parent/child `File` graph (`RecursionError` in `full_path` and in the read-only tree/
  Tikz/CSV/locate walkers)
- a `None`-valued NTFS timestamp field during `restore` (`AttributeError` from `None.astimezone()`)
- an out-of-1970-range timestamp -- reachable with an ordinary corrupted or zeroed date, not even
  adversarial (`time.mktime` raises `OverflowError`, not the `ValueError` the code catches)
- a non-resident `$ATTRIBUTE_LIST` with a truncated `real_size` field (`TypeError` from
  `min(int, None)`)
- a truncated INDX record (`TypeError` from `None += 24`)

One caveat: there's only one registered scanner (`NTFSScanner`), so if it raises partway through
`get_partitions()` there's no partial-result recovery within that pass -- this turns the failure
into a clean logged error + the REPL still starting (instead of the process exiting), not into
parsing the rest of the image.