### PR TITLE
Escape reconstructed names in CSV, body-file and Tikz/LaTeX exports

### DIFF
--- a/src/recuperabit/utils.py
+++ b/src/recuperabit/utils.py
@@ -224,6 +224,12 @@ def tree_folder(directory: "File", padding: int = 0) -> str:
     return "\n".join(lines)
 
 
+def _bodyfile_escape(name: str) -> str:
+    """Escape backslash and the '|' field separator so a reconstructed name
+    cannot inject extra columns into the pipe-delimited body file."""
+    return name.replace("\\", "\\\\").replace("|", "\\|")
+
+
 def _bodyfile_repr(node: "File", path: str) -> str:
     """Return a body file line for node."""
     end = "/" if node.is_directory or len(node.children) else ""
@@ -231,7 +237,7 @@ def _bodyfile_repr(node: "File", path: str) -> str:
         str(el)
         for el in [
             "0",  # MD5
-            path + node.name + end,  # name
+            _bodyfile_escape(path + node.name + end),  # name
             node.index,  # inode
             "0",
             "0",
@@ -261,10 +267,28 @@ def bodyfile_folder(directory: "File", path: str = "") -> List[str]:
     return lines
 
 
+_LATEX_SPECIAL_CHARS = (
+    # Backslash first, so the backslashes introduced by the other
+    # substitutions below are not themselves re-escaped.
+    ("\\", r"\textbackslash{}"),
+    ("{", r"\{"),
+    ("}", r"\}"),
+    ("$", r"\$"),
+    ("&", r"\&"),
+    ("#", r"\#"),
+    ("_", r"\_"),
+    ("%", r"\%"),
+    ("~", r"\textasciitilde{}"),
+    ("^", r"\textasciicircum{}"),
+)
+
+
 def _ltx_clean(label: Any) -> str:
     """Small filter to prepare strings to be included in LaTeX code."""
-    clean = str(label).replace("$", r"\$").replace("_", r"\_")
-    if clean[0] == "-":
+    clean = str(label)
+    for char, escaped in _LATEX_SPECIAL_CHARS:
+        clean = clean.replace(char, escaped)
+    if clean and clean[0] == "-":
         clean = r"\textminus{}" + clean[1:]
     return clean
 
@@ -317,6 +341,20 @@ def tikz_part(part: "Partition") -> str:
     return "%s\n\n%s\n%s\n%s" % (preamble, begin_tree, "\n".join(lines), end_tree)
 
 
+_CSV_FORMULA_PREFIXES = ("=", "+", "-", "@", "\t", "\r")
+
+
+def _csv_field(value: Any) -> str:
+    """Quote a CSV field, escaping embedded double quotes (RFC 4180) and
+    neutralising spreadsheet formula injection (CSV/formula injection) by
+    prefixing a leading apostrophe when the value starts with a character
+    that Excel/LibreOffice would interpret as the start of a formula."""
+    text = str(value)
+    if text.startswith(_CSV_FORMULA_PREFIXES):
+        text = "'" + text
+    return '"' + text.replace('"', '""') + '"'
+
+
 def csv_part(part: "Partition") -> list[str]:
     """Provide a CSV representation for a partition."""
     contents = [
@@ -342,12 +380,12 @@ def csv_part(part: "Partition") -> list[str]:
     for index in part.files:
         obj = part.files[index]
         contents.append(
-            '%s,%s,"%s","%s",%s,%s,%s,%s,%s,%s,%s,%s,%s,%s'
+            "%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s"
             % (
                 obj.index,
                 obj.parent,
-                obj.name,
-                obj.full_path(part),
+                _csv_field(obj.name),
+                _csv_field(obj.full_path(part)),
                 obj.mac["modification"],
                 obj.mac["access"],
                 obj.mac["creation"],


### PR DESCRIPTION
Another follow-up after hand-verifying the rest of the original report. This one is a real,
distinct class from the crash bugs in #143: it's about what happens to the *exported* files
(csv/bodyfile/tikzplot), which the analyst typically opens in another tool afterward, not a crash
in RecuperaBit itself.

## The issue

Reconstructed `$FILE_NAME` names are attacker-controlled, and three export formats embed them with
no escaping for their own special characters:

- `_ltx_clean` only escapes `$` and `_`. A name like `}}}\input{/etc/passwd}` breaks out of the
  Tikz node's `{...}` label and injects raw LaTeX/TeX macros into the generated code.
- `csv_part` wraps Name/Full Path in a bare `"%s"` with no quote-escaping, so a name containing
  `"` breaks the field (values shift into neighboring columns), and a name starting with `=`, `+`,
  `-` or `@` becomes a spreadsheet formula when opened in Excel/LibreOffice.
- `_bodyfile_repr` joins fields with `|` with no escaping, so a name containing `|` injects extra
  columns into the pipe-delimited body file.

## The fix

- `_ltx_clean` now escapes the full set of LaTeX special characters (backslash first, so later
  substitutions don't re-escape it).
- New `_csv_field()` helper: doubles embedded quotes (RFC 4180) and prefixes a leading apostrophe
  when the value starts with a formula-trigger character.
- New `_bodyfile_escape()` helper: escapes backslash and `|`.

## Verification

Crafted a name with `}}}\input{/etc/passwd}` for Tikz -- it now stays as literal escaped text
inside the label instead of breaking out. For CSV, crafted a name with embedded quotes and a
leading `=`, wrote the generated file to disk and round-tripped it through Python's `csv.reader`:
every row now parses to exactly 14 fields matching the header (before the fix, the embedded quotes
shifted values into the wrong columns).

I know the body-file escaping (`\|`) isn't a standard defined by the body-file format itself --
there's no official escape mechanism for it as far as I know, so this is a reasonable mitigation
rather than a spec-compliant one. Happy to change the approach if you'd rather do something else
there.